### PR TITLE
Fix final ESLint error: remove inline type annotation in filter function

### DIFF
--- a/src/components/ProjectsSearchView.tsx
+++ b/src/components/ProjectsSearchView.tsx
@@ -134,7 +134,7 @@ export function ProjectsSearchView({ initialFilters = {} }: ProjectsSearchViewPr
       }
       
       if (filters.frameworkProgramme) {
-        filteredProjects = filteredProjects.filter((p: { frameworkprogramme: string }) => p.frameworkprogramme === filters.frameworkProgramme);
+        filteredProjects = filteredProjects.filter(p => p.frameworkprogramme === filters.frameworkProgramme);
       }
       
       setProjects(filteredProjects as CordisProject[]);


### PR DESCRIPTION
- Remove explicit type annotation (p: { frameworkprogramme: string })
- Let TypeScript infer the correct type for filter parameter
- This resolves the last ESLint error blocking Vercel deployment
- Build now passes successfully with all linting checks